### PR TITLE
Update Notebook.ipynb

### DIFF
--- a/Content/units/Data-Handling/2. Data Manipulation with Pandas/4. DataFrame Manipulations/Notebook.ipynb
+++ b/Content/units/Data-Handling/2. Data Manipulation with Pandas/4. DataFrame Manipulations/Notebook.ipynb
@@ -1120,7 +1120,7 @@
     "})\n",
     "\n",
     "# Grouping by 'Department'\n",
-    "grouped_df = data.groupby('Department').mean()\n",
+    "grouped_df = data.groupby('Department')[['Sales', 'Performance Score']].mean()\n",
     "grouped_df.head()"
    ]
   },


### PR DESCRIPTION
Modification to resolve the following error:

FutureWarning: The default value of numeric_only in DataFrameGroupBy.mean is deprecated. In a future version, numeric_only will default to False. Either specify numeric_only or select only columns which should be valid for the function.
  grouped_df = data.groupby('Department').mean()
Specified numeric only columns